### PR TITLE
 # Migrate database to PostgreSQL - Temporal free host with 20MB

### DIFF
--- a/PracticaEs/PracticaEs/settings.py
+++ b/PracticaEs/PracticaEs/settings.py
@@ -76,8 +76,12 @@ WSGI_APPLICATION = 'PracticaEs.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'meqbvape',
+        'USER': 'meqbvape',
+        'PASSWORD': '8ZHQQMNLvFiiPZBgNhNqVjm68JApFPqj',
+        'HOST': 'manny.db.elephantsql.com',
+        'PORT': '',
     }
 }
 


### PR DESCRIPTION
Migrated database to POSTGRESQL api.elephantsql.com
We only have 20MB free and theres actually 1MB already in use, the database is temporal and will change for one that can handle more data.